### PR TITLE
Cropping images (to fit square aspect ratio) on artist screen.

### DIFF
--- a/app/src/main/java/com/craftworks/music/ui/elements/ArtistCard.kt
+++ b/app/src/main/java/com/craftworks/music/ui/elements/ArtistCard.kt
@@ -55,7 +55,7 @@ fun ArtistCard(artist: Artist, onClick: () -> Unit){
                     model = if (artist.imageUri != Uri.EMPTY) artist.imageUri else null,
                     placeholder = painterResource(R.drawable.rounded_artist_24),
                     fallback = painterResource(R.drawable.rounded_artist_24),
-                    contentScale = ContentScale.FillWidth,
+                    contentScale = ContentScale.Crop,
                     contentDescription = "Album Image",
                     modifier = Modifier
                         .fillMaxHeight()


### PR DESCRIPTION
Hello,

Very small change, but I think it looks better this way. Not sure if this is necessary for cover art too, since covers usually are square.

Before:
![image](https://github.com/CraftWorksMC/Chora/assets/57940399/6324fa47-61cd-4263-9fe1-d9981b989b34)

After:
![image](https://github.com/CraftWorksMC/Chora/assets/57940399/d3458859-b4c8-4250-8ed3-4c579cf1743d)
