### PR TITLE
Fix focusability of text field in Settings Appearance screen

### DIFF
--- a/app/src/main/java/com/craftworks/music/ui/screens/settings/SettingsAppearance.kt
+++ b/app/src/main/java/com/craftworks/music/ui/screens/settings/SettingsAppearance.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.Role
@@ -66,7 +67,6 @@ import com.craftworks.music.managers.SettingsManager
 import com.craftworks.music.ui.elements.dialogs.BackgroundDialog
 import com.craftworks.music.ui.elements.dialogs.NavbarItemsDialog
 import com.craftworks.music.ui.elements.dialogs.ThemeDialog
-import com.craftworks.music.ui.elements.dialogs.dialogFocusable
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
@@ -81,7 +81,8 @@ fun S_AppearanceScreen(navHostController: NavHostController = rememberNavControl
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
 
-    val focusRequester = FocusRequester()
+    val focusRequester = remember { FocusRequester() }
+    val focusManager = LocalFocusManager.current
 
     Column(
         modifier = Modifier
@@ -92,7 +93,11 @@ fun S_AppearanceScreen(navHostController: NavHostController = rememberNavControl
                     .asPaddingValues()
                     .calculateTopPadding()
             )
-            .dialogFocusable()
+            .clickable(
+                onClick = { focusManager.clearFocus() },
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() }
+            )
             //.background(MaterialTheme.colorScheme.background)
     ) {
 


### PR DESCRIPTION
# Motivation

In the current version, the username text field is automatically focused when navigating to "Appearance" page of settings, and it won't be unfocused even if tapping elsewhere or clicking "Back" button. It also automatically pops up the screen keyboard and will be a bit annoying if someone wants to do other settings other than username.

# Mechanism

Well I should admit that I have little knowledge and experience on focus properties of Android apps. LLM has been involved in the change. However, it may be confirmed that `Modifier.dialogFocusable()` of `Column` element avoids the expected behavior.

For other information, please check the commit message.

# Test environments

This commit has been tested on:

- Pixel 3a API 28 (Android Studio emulator);
- Pixel 7 API 36.

# Related issues

- #43 (only part of it)